### PR TITLE
fix background scaling for large and small screens

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -94,6 +94,7 @@
     top: 0px;
     left: 0px;
     background: url('../img/bg/1.jpg') center fixed;
+    background-size: cover;
     z-index: 0;
 }
 


### PR DESCRIPTION
application of `background-size: cover` to set background image to scale to size of screen.  applied as distinct rule so that inline background reapplication won't destroy.  (yay cascade)

before: ![before](http://imgur.com/ROrmxoc)

after: ![after](http://imgur.com/KnSx01F)

---

Ugh, github's replacing the image links with its own, and they're failing.  Let's see if literals work.

before: http://imgur.com/ROrmxoc (imgur .com/ROrmxoc)

after: http://imgur.com/KnSx01F (imgur .com/KnSx01F)
